### PR TITLE
[macOS] zcash.conf is located in $HOME/Library/Application Support

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -101,6 +101,8 @@ bool Settings::loadFromFile() {
 
 #ifdef Q_OS_LINUX
 	confLocation = QStandardPaths::locate(QStandardPaths::HomeLocation, ".zcash/zcash.conf");
+#elif defined(Q_OS_DARWIN)
+	confLocation = QStandardPaths::locate(QStandardPaths::HomeLocation, "/Library/Application Support/Zcash/zcash.conf");
 #else
 	confLocation = QStandardPaths::locate(QStandardPaths::AppDataLocation, "../../Zcash/zcash.conf");
 #endif


### PR DESCRIPTION
zcash.conf is located in $HOME/Library/Application Support/Zcash/zcash.conf on macOS
https://github.com/zcash/zcash/blob/186874bb83658074a785574fc26ee17118219acc/src/util.cpp#L478